### PR TITLE
Add Vertical Initiation Prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ npm install react-native-deck-swiper --save
 | infinite | bool | keep swiping indefinitely | | false |
 | horizontalSwipe | bool | enable/disable horizontal swiping | | true |
 | verticalSwipe | bool | enable/disable vertical swiping | | true |
+| verticalInitiation | bool | enable/disable starting a swipe moving vertically | true |
 | showSecondCard | bool | enable/disable second card while swiping | | true |
 
 ### Event callbacks

--- a/Swiper.js
+++ b/Swiper.js
@@ -105,7 +105,7 @@ class Swiper extends Component {
         const isVerticalSwipe = Math.sqrt(
           Math.pow(gestureState.dx, 2) < Math.pow(gestureState.dy, 2)
         )
-        if (!this.props.verticalSwipe && isVerticalSwipe) {
+        if ((!this.props.verticalSwipe || !this.props.verticalInitiation) && isVerticalSwipe) {
           return false
         }
         return Math.sqrt(Math.pow(gestureState.dx, 2) + Math.pow(gestureState.dy, 2)) > 10
@@ -807,6 +807,7 @@ Swiper.propTypes = {
   swipeBackCard: PropTypes.bool,
   swipeBackFriction: PropTypes.number,
   verticalSwipe: PropTypes.bool,
+  verticalInitiation: PropTypes.bool,
   verticalThreshold: PropTypes.number,
   zoomAnimationDuration: PropTypes.number,
   zoomFriction: PropTypes.number,
@@ -908,6 +909,7 @@ Swiper.defaultProps = {
   swipeBackAnimationDuration: 600,
   swipeBackCard: false,
   swipeBackFriction: 11,
+  verticalInitiation: true,
   verticalSwipe: true,
   verticalThreshold: height / 5,
   zoomAnimationDuration: 100,


### PR DESCRIPTION
The vertical initiation prop can be set to false to prevent vertical swipes from starting a card swipe.

After the card swipe animation begins, however, the card animation may move vertically